### PR TITLE
Upgrade CI runner image from deprecated ubuntu-20.04 to ubuntu-latest

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: "1"
       COMPOSE_DOCKER_CLI_BUILD: "1"
@@ -22,7 +22,7 @@ jobs:
       - run: docker compose -f docker-compose.test.yml up --exit-code-from test
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       SKAFFOLD_DEFAULT_REPO: ghcr.io/con2
     steps:


### PR DESCRIPTION
The `ubuntu-20.04` runner image will be removed in April, so we need to upgrade it to an up-to-date one. Suggest using the `ubuntu-latest` so that we don't need to do this manually again.