### PR TITLE
ci: Fix "Workflow does not contain permissions" security notices

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,5 +1,9 @@
 name: cicd
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:
@@ -35,8 +39,8 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_PASSWORD }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/setup-buildx-action@v3
       - id: build
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,8 @@
 name: Test
+
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Fixes these GitHub Code Security alerts:

https://github.com/con2/kirppu/security/code-scanning/1
https://github.com/con2/kirppu/security/code-scanning/2
https://github.com/con2/kirppu/security/code-scanning/3
https://github.com/con2/kirppu/security/code-scanning/4
https://github.com/con2/kirppu/security/code-scanning/5