### PR TITLE
Use new self-hosted runners for GitHub Actions

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -60,7 +60,7 @@ jobs:
 
   # TODO DRY
   deploy_staging:
-    runs-on: self-hosted
+    runs-on: qb-arc-runners
     needs: build
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/development' }}
     steps:
@@ -76,7 +76,7 @@ jobs:
           emskaffolden -E staging -- deploy -n kirppu-staging -a build.json
 
   deploy_production:
-    runs-on: self-hosted
+    runs-on: qb-arc-runners
     needs: build
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     steps:


### PR DESCRIPTION
See
https://con2.slack.com/archives/C3ZGNGY48/p1769341041931959
https://outline.con2.fi/doc/github-actions-cicd-Hdu77klcIJ
https://outline.con2.fi/doc/actions-runner-controller-arc-810fsxQFq0
