### PR TITLE
kubernetes: move to Traefik

### DIFF
--- a/.github/cache-tools/action.yaml
+++ b/.github/cache-tools/action.yaml
@@ -1,8 +1,8 @@
 # https://github.com/kubernetes/kubernetes/releases
 # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/
 # STABLE=https://dl.k8s.io/release/stable.txt
-# - https://dl.k8s.io/release/v1.20.4/bin/linux/amd64/kubectl
-# - https://dl.k8s.io/release/v1.20.4/bin/linux/amd64/kubectl.sha256
+# - https://dl.k8s.io/release/v1.36.2/bin/linux/amd64/kubectl
+# - https://dl.k8s.io/release/v1.36.2/bin/linux/amd64/kubectl.sha256
 
 # https://github.com/GoogleContainerTools/skaffold/releases
 # - https://storage.googleapis.com/skaffold/releases/v1.20.0/skaffold-linux-amd64
@@ -12,10 +12,10 @@ runs:
   using: composite
   steps:
     - id: cache-bin
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: bin
-        key: ${{ runner.os }}-bin-v1
+        key: ${{ runner.os }}-bin-v2
     - if: steps.cache-bin.outputs.cache-hit != 'true'
       name: Download tools
       shell: bash
@@ -23,8 +23,8 @@ runs:
         mkdir bin
         curl -Lo bin/skaffold https://storage.googleapis.com/skaffold/releases/v1.20.0/skaffold-linux-amd64
         echo "725b5b5b9456cb1abc26c8a7528906e27c30980cda79249d780618c3834a7aa3  bin/skaffold" | sha256sum -c -
-        curl -Lo bin/kubectl https://dl.k8s.io/release/v1.20.4/bin/linux/amd64/kubectl
-        echo "98e8aea149b00f653beeb53d4bd27edda9e73b48fed156c4a0aa1dabe4b1794c  bin/kubectl" | sha256sum -c -
+        curl -Lo bin/kubectl https://dl.k8s.io/release/v1.36.2/bin/linux/amd64/kubectl
+        echo "1e9045ec32bea85da43de85f0065358529ea7c7a152eca78154fba5b58c27d82  bin/kubectl" | sha256sum -c -
         chmod +x bin/skaffold bin/kubectl
     - name: Add tools to PATH
       shell: bash

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -21,8 +21,8 @@ jobs:
       DOCKER_BUILDKIT: "1"
       COMPOSE_DOCKER_CLI_BUILD: "1"
     steps:
-      - uses: &checkout-action actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: &buildx-action docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - uses: &checkout-action actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: &buildx-action docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - run: docker compose -f docker-compose.test.yml up --exit-code-from test
 
   build:
@@ -31,11 +31,11 @@ jobs:
       SKAFFOLD_DEFAULT_REPO: ghcr.io/con2
     steps:
       - uses: *checkout-action
-      - uses: &python-action actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: &python-action actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.11'
       - uses: ./.github/cache-tools
-      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         if: ${{ github.event_name == 'push' }}
         with:
           registry: ghcr.io

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
   Test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
           cache: pip

--- a/kubernetes/default.vars.yaml
+++ b/kubernetes/default.vars.yaml
@@ -43,7 +43,7 @@ djangoapp_allowed_hosts: !Concat
 ingress_letsencrypt_enabled: false
 ingress_letsencrypt_cluster_issuer: letsencrypt-prod
 
-ingress_class_name: nginx
+ingress_class_name: traefik
 
 # NOTE: "managed" PostgreSQL should not be considered production-ready.
 postgres_managed: true
@@ -153,14 +153,20 @@ gunicorn_environment:
         name: !Var djangoapp_name
         key: kompassiApiApplicationPassword
 
-# Default annotations work for nginx ingress with or without LetsEncrypt TLS. Override if you need something else.
-base_ingress_annotations: []
+# The https-redirect middleware must only be attached where TLS is actually configured
+# (not local/dev without letsencrypt) - see infrastructure/kubernetes/traefik-middlewares.yaml
+# for why this is a per-app opt-in Middleware rather than a global entrypoint redirect
+# (ACME HTTP-01 safety). kirppu-backup always has TLS (manually managed cert), so it
+# gets the middleware unconditionally via base_ingress_annotations.
+base_ingress_annotations:
+  traefik.ingress.kubernetes.io/router.middlewares: default-https-redirect@kubernetescrd
 
+# Default annotations work with or without LetsEncrypt TLS. Override if you need something else.
 ingress_annotations: !If
   test: !Var ingress_letsencrypt_enabled
   then:
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    traefik.ingress.kubernetes.io/router.middlewares: default-https-redirect@kubernetescrd
 
 ingress_tls: !If
   test: !Var ingress_letsencrypt_enabled

--- a/kubernetes/ingress/ingress-backup.in.yaml
+++ b/kubernetes/ingress/ingress-backup.in.yaml
@@ -2,9 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: !Format "{djangoapp_name}-backup"
-  annotations: !Merge
-    - !Var base_ingress_annotations
-    - nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  annotations: !Var base_ingress_annotations
 spec:
   ingressClassName: !Var ingress_class_name
   tls:


### PR DESCRIPTION
NOTE: Let me handle merging – needs to be synced with ingress controller flip

ingressClassName and ssl-redirect move to Traefik - the shared
https-redirect Middleware, attached only when TLS is actually configured
(see infrastructure/kubernetes/traefik-migration-inventory.md for the
overall migration this is part of). kirppu-backup always has TLS
(manually-managed cert) so it gets the middleware unconditionally.
